### PR TITLE
Adiciona consulta de exceção de proposta para acordos maleáveis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.3 (12/12/2018)
+
+* Implementa `GetExceptionStatus`
+
 ### 0.1.2 (25/10/2018)
 
 * Implementa `GetInstallments`

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    credigy (0.1.2)
+    credigy (0.1.3)
       activesupport
       savon (~> 2)
 
@@ -47,7 +47,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -100,4 +100,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Credigy::LegalTermsAcceptance.new(authorization_token).call
 ### GetExceptionStatus
 
 ```ruby
-response = Credigy::LegalTermsAcceptance.new(authorization_token, agreement_id: 12345).call
+response = Credigy::AgreementExceptionStatus.new(authorization_token, agreement_id: 12345).call
 response.exception_id # id da exceção provisionada
 response.status # status da exceção provisionada
 ```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Ou instale você mesmo:
 
 - [Login](#login)
 - [AcceptLegalTerms](#acceptlegalterms)
+- [GetExceptionStatus](#getexceptionstatus)
 - [GeneratePromise](#generatepromise)
 - [GetAccounts](#getaccounts)
 - [GetBoleto](#getboleto)
@@ -49,6 +50,14 @@ authorization_token = response.authorization_token
 
 ```ruby
 Credigy::LegalTermsAcceptance.new(authorization_token).call
+```
+
+### GetExceptionStatus
+
+```ruby
+response = Credigy::LegalTermsAcceptance.new(authorization_token, agreement_id: 12345).call
+response.exception_id # id da exceção provisionada
+response.status # status da exceção provisionada
 ```
 
 ### GeneratePromise

--- a/lib/credigy.rb
+++ b/lib/credigy.rb
@@ -5,6 +5,7 @@ require "credigy/version"
 
 require "credigy/config"
 require "credigy/account"
+require "credigy/agreement_exception_status"
 require "credigy/boleto"
 require "credigy/campaign_negotiation"
 require "credigy/email"

--- a/lib/credigy/agreement_exception_status.rb
+++ b/lib/credigy/agreement_exception_status.rb
@@ -1,0 +1,22 @@
+require_relative './authorized'
+require_relative './agreement_exception_status_response'
+
+module Credigy
+  class AgreementExceptionStatus < Authorized
+    attr_reader :agreement_id
+
+    def initialize(authorization_token, agreement_id:)
+      @authorization_token, @agreement_id = authorization_token, agreement_id
+    end
+
+    def operation
+      :get_exception_status
+    end
+
+    def message
+      {
+        'cred:debtorAgreementID' => agreement_id
+      }
+    end
+  end
+end

--- a/lib/credigy/agreement_exception_status_response.rb
+++ b/lib/credigy/agreement_exception_status_response.rb
@@ -1,0 +1,13 @@
+require_relative './response'
+
+module Credigy
+  class AgreementExceptionStatusResponse < Response
+    def exception_id
+      body[:exception_id]
+    end
+
+    def status
+      body[:status]
+    end
+  end
+end

--- a/lib/credigy/version.rb
+++ b/lib/credigy/version.rb
@@ -1,3 +1,3 @@
 module Credigy
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/credigy/agreement_exception_status_response_spec.rb
+++ b/spec/credigy/agreement_exception_status_response_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Credigy::AgreementExceptionStatusResponse do
+  subject { described_class.new(:_, :_) }
+
+  describe '#exception_id' do
+    let(:body) { { exception_id: 'exception_id' } }
+
+    it do
+      expect(subject).to receive(:body).and_return(body)
+      expect(subject.exception_id).to eq('exception_id')
+    end
+  end
+
+  describe '#status' do
+    let(:body) { { status: 'status' } }
+
+    it do
+      expect(subject).to receive(:body).and_return(body)
+      expect(subject.status).to eq('status')
+    end
+  end
+end

--- a/spec/credigy/agreement_exception_status_spec.rb
+++ b/spec/credigy/agreement_exception_status_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Credigy::AgreementExceptionStatus do
+  subject { described_class.new(:authorization_token, agreement_id: 123) }
+
+  describe '#operation' do
+    it do
+      expect(subject.operation).to eq(:get_exception_status)
+    end
+  end
+
+  describe '#message' do
+    it do
+      expect(subject.message).to eq({ 'cred:debtorAgreementID' => 123 })
+    end
+  end
+end


### PR DESCRIPTION
Método responsável para consultar o aceite de uma proposta de acordo fora dos padrões pré estabelecidos pela Credigy.